### PR TITLE
Workflow to release to PyPi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: "Release"
+
+on:
+  push:
+    tags:
+      # Publish on any tag starting with a `v`, e.g., v0.1.0
+      - v*
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Build
+        run: uv build --all-packages --sdist
+
+      - name: Publish
+        run: uv publish


### PR DESCRIPTION
This workflow releases our packages to PyPi.

We build and publish all packages when a new tag is created.
A prerequisite for pushing to PyPi is that `ing-bank/ordeq` is added as trusted publisher.
This is currently done manually.
Check out the uv docs [here](https://docs.astral.sh/uv/guides/integration/github/#publishing-to-pypi).