### PR TITLE
docs: tweaks and fixes

### DIFF
--- a/docs/contributing/documentation.md
+++ b/docs/contributing/documentation.md
@@ -9,18 +9,10 @@ To view the documentation locally, first install all dependencies:
 just install
 ```
 
-Next, generate the API documentation:
-
-```shell
-uv run python scripts/generate_api_docs.py
-```
-
 To spin up the documentation server, run:
 
 ```shell
-uv run mkdocs serve
+just docs-serve
 ```
-
-Optionally, use the `--strict` flag that causes the build fail on warnings, for instance due to missing links.
 
 Now navigate to [http://127.0.0.1:8000/](http://127.0.0.1:8000/) and enjoy the documentation!

--- a/docs/getting-started/concepts/catalogs.md
+++ b/docs/getting-started/concepts/catalogs.md
@@ -143,7 +143,7 @@ This way, the `staging` catalog inherits all IOs from `production`, except for `
 
 You can also extend catalogs, as follows:
 
-```python title="catalogs/staging.py"  hl_lines="5"
+```python title="catalogs/staging.py"  hl_lines="6"
 from ordeq_spark import SparkCSV
 
 from catalogs.production import *

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -57,7 +57,7 @@ Also, the logic is still tightly coupled, and you cannot easily reuse parts of i
 Can we do better?
 Let's try to modularize the logic by splitting it into functions:
 
-```python hl_lines="5 6 8 9 11-14 16-18" title="__main__.py"
+```python hl_lines="6 7 10 11 14-17 20-22" title="__main__.py"
 from pyspark.sql import SparkSession
 from argparse import ArgumentParser
 from pyspark.sql import DataFrame
@@ -365,7 +365,7 @@ For example, we might want to add a node that aggregates the transaction amount 
 
 === "catalog.py"
 
-    ```python hl_lines="12-16"
+    ```python hl_lines="10-12"
     from ordeq_args import EnvironmentVariable
     from ordeq_spark import SparkIcebergTable, SparkHiveTable
 

--- a/docs/guides/custom_io.md
+++ b/docs/guides/custom_io.md
@@ -7,7 +7,7 @@ Frequently used IO implementations are offered out-of-the-box as `ordeq` package
 For instance, there is support for JSON, YAML, Pandas, NumPy, Polars and many more.
 These can be used where applicable and serve as reference implementation for new IO classes.
 
-## 1. Understanding the IO Base Class
+## Understanding the IO Base Class
 
 The `IO` class is an abstract base class that defines the structure for loading and saving data.
 It includes the following key methods:
@@ -15,72 +15,72 @@ It includes the following key methods:
 - **`load()`**: Method to be implemented by subclasses for loading data.
 - **`save(data)`**: Method to be implemented by subclasses for saving data.
 
-## 2. Example: FaissIndex
+## Example: FaissIndex
 
-Before creating a custom IO class step-by-step, first consider the following implementation using the Faiss library.
+Before creating a custom IO class, first consider the following implementation using the Faiss library.
 The `FaissIndex` class extends the `IO` class and implements the `load` and `save` methods:
 
-```pycon
->>> from dataclasses import dataclass
->>> from pathlib import Path
->>> import faiss
->>> from ordeq.framework.io import IO
->>> @dataclass(frozen=True, kw_only=True)
-... class FaissIndex(IO[faiss.Index]):
-...     path: Path
-...
-...     def load(self) -> faiss.Index:
-...         return faiss.read_index(str(self.path))
-...
-...     def save(self, index: faiss.Index) -> None:
-...         faiss.write_index(index, str(self.path))
+```python
+from dataclasses import dataclass
+from pathlib import Path
+import faiss
+from ordeq.framework.io import IO
 
+
+@dataclass(frozen=True, kw_only=True)
+class FaissIndex(IO[faiss.Index]):
+    path: Path
+
+    def load(self) -> faiss.Index:
+        return faiss.read_index(str(self.path))
+
+    def save(self, index: faiss.Index) -> None:
+        faiss.write_index(index, str(self.path))
 ```
 
-## 3. Creating Your Own IO Class
+## Creating Your Own IO Class
 
 In this section, we will go step-by-step through the creation of a simple text-based file dataset.
 
-### Step 3.1: Define Your IO Class
+### Define Your IO Class
 
 Create a new class that extends the `IO` class and implement the `load` and `save` methods.
 
-```pycon
->>> from dataclasses import dataclass
->>> from pathlib import Path
->>> from ordeq.framework.io import IO
->>> @dataclass(frozen=True, kw_only=True)
-... class CustomIO(IO):
-...     path: Path
-...
-...     def load(self):
-...         pass
-...
-...     def save(self, data):
-...         pass
+```python
+from dataclasses import dataclass
+from pathlib import Path
+from ordeq.framework.io import IO
 
+
+@dataclass(frozen=True, kw_only=True)
+class CustomIO(IO):
+    path: Path
+
+    def load(self):
+        pass
+
+    def save(self, data):
+        pass
 ```
 
-### Step 3.2: Implement the `load` Method
+### Implement the `load` Method
 
 This method should contain the logic for loading your data.
 For example:
 
-```pycon
+```python
 def load(self):
     return self.path.read_text()
-
 ```
 
-### Step 3.3: Implement the `save` Method
+### Implement the `save` Method
 
 This method should contain the logic for saving your data.
 For example:
 
-```pycon
+```python
 def save(self, data):
     self.path.write_text(data)
-
 ```
 
 ### Load- or save arguments
@@ -89,41 +89,43 @@ The `path` attribute is used by both the `load` and `save` method.
 It's also possible to provide parameters to the individual methods.
 For instance, we could let the user control the newline character used by `write_text`:
 
-```pycon
->>> from dataclasses import dataclass
->>> from pathlib import Path
->>> from ordeq.framework.io import IO
->>> @dataclass(frozen=True, kw_only=True)
-... class CustomIO(IO):
-...     path: Path
-...
-...     def load(self):
-...         return self.path.read_text()
-...
-...     def save(self, data, newline: str = "\n"):
-...         self.path.write_text(data, newline=newline)
+```python
+from dataclasses import dataclass
+from pathlib import Path
+from ordeq.framework.io import IO
 
+
+@dataclass(frozen=True, kw_only=True)
+class CustomIO(IO):
+    path: Path
+
+    def load(self):
+        return self.path.read_text()
+
+    def save(self, data, newline: str = "\n"):
+        self.path.write_text(data, newline=newline)
 ```
 
 A common pattern when using third party functionality is to delegate keyword arguments to another function.
 
 Below is an example of this for a Pandas CSV IO class:
 
-```pycon
->>> from dataclasses import dataclass
->>> from pathlib import Path
->>> import pandas as pd
->>> from ordeq.framework.io import IO
->>> @dataclass(frozen=True, kw_only=True)
-... class PandasCSV(IO[pd.DataFrame]):
-...     path: Path
-...
-...     def load(self, **load_args) -> pd.DataFrame:
-...        return pd.read_csv(self.path, **load_args)
-...
-...     def save(self, data: pd.DataFrame, **save_args):
-...         data.write_csv(self.path, **save_args)
+```python
+from dataclasses import dataclass
+from pathlib import Path
+import pandas as pd
+from ordeq.framework.io import IO
 
+
+@dataclass(frozen=True, kw_only=True)
+class PandasCSV(IO[pd.DataFrame]):
+    path: Path
+
+    def load(self, **load_args) -> pd.DataFrame:
+        return pd.read_csv(self.path, **load_args)
+
+    def save(self, data: pd.DataFrame, **save_args):
+        data.write_csv(self.path, **save_args)
 ```
 
 ### Providing type information
@@ -131,20 +133,23 @@ Below is an example of this for a Pandas CSV IO class:
 We can provide the `str` argument to `IO` to indicate that `CustomIO` class loads and saves strings.
 This type should match the return type of the `load` method and the first parameter of the `save` method.
 
-```pycon
->>> from dataclasses import dataclass
->>> from pathlib import Path
->>> from ordeq.framework.io import IO
->>> @dataclass(frozen=True, kw_only=True)
-... class CustomIO(IO[str]):  # IO operates on type `str`
-...     path: Path
-...
-...     def load(self) -> str:  # and thus returns a `str` on load
-...         return self.path.read_text()
-...
-...     def save(self, data: str) -> None:  # and takes a `str` as first argument to `save`
-...         self.path.write_text(data)
+```python
+from dataclasses import dataclass
+from pathlib import Path
+from ordeq.framework.io import IO
 
+
+@dataclass(frozen=True, kw_only=True)
+class CustomIO(IO[str]):  # IO operates on type `str`
+    path: Path
+
+    def load(self) -> str:  # and thus returns a `str` on load
+        return self.path.read_text()
+
+    def save(
+        self, data: str
+    ) -> None:  # and takes a `str` as first argument to `save`
+        self.path.write_text(data)
 ```
 
 ### Read-only and write-only classes
@@ -162,31 +167,33 @@ Practical examples are:
 For a practical example of a class that is Read-only, we will consider generating of synthetic sensor data.
 The `SensorDataGenerator` class will extend the `Input` class, meaning it will only have to implement the `load` method.
 
-```pycon
->>> import random
->>> from dataclasses import dataclass
->>> from typing import Any
->>> from ordeq.framework.io import Input
->>> @dataclass(frozen=True, kw_only=True)
-... class SensorDataGenerator(Input[dict[str, Any]]):
-...     """Example Input class to generate synthetic sensor data
-...
-...     Examples:
-...     >>> generator = SensorDataGenerator(sensor_id="sensor_3")
-...     >>> data = generator.load()
-...     {'sensor_id': 'sensor_3', 'temperature': 22.001252691230633, 'humidity': 35.2674852725557}
-...     """
-...
-...     sensor_id: str
-...
-...     def load(self) -> dict[str, Any]:
-...         """Simulate reading data from a sensor"""
-...         return {
-...             "sensor_id": self.sensor_id,
-...             "temperature": random.uniform(20.0, 30.0),
-...             "humidity": random.uniform(30.0, 50.0)
-...         }
+```python
+import random
+from dataclasses import dataclass
+from typing import Any
+from ordeq.framework.io import Input
 
+
+@dataclass(frozen=True, kw_only=True)
+class SensorDataGenerator(Input[dict[str, Any]]):
+    """Example Input class to generate synthetic sensor data
+
+    Example usage:
+
+        >>> generator = SensorDataGenerator(sensor_id="sensor_3")
+        >>> data = generator.load()
+        {'sensor_id': 'sensor_3', 'temperature': 22.001252691230633, 'humidity': 35.2674852725557}
+    """
+
+    sensor_id: str
+
+    def load(self) -> dict[str, Any]:
+        """Simulate reading data from a sensor"""
+        return {
+            "sensor_id": self.sensor_id,
+            "temperature": random.uniform(20.0, 30.0),
+            "humidity": random.uniform(30.0, 50.0),
+        }
 ```
 
 Saving data using this dataset would raise a `ordeq.framework.io.IOException` explaining the save method is not implemented.

--- a/docs/guides/examples/benchmark_node_runtime.md
+++ b/docs/guides/examples/benchmark_node_runtime.md
@@ -5,9 +5,7 @@ track of node execution durations. Using hooks to achieve this has the
 advantage that the timing does not add cognitive complexity to the dataset
 transformations. It also avoids repetitive boilerplate code inside the nodes.
 
-`timer_hook.py`:
-
-```pycon
+```pycon title="timer_hook.py"
 >>> from time import perf_counter
 >>>
 >>> from ordeq import Node, NodeHook


### PR DESCRIPTION
- refer to `just` command for documentation serving
- fix highlighting of lines after linting
- use title for timer hook
- remove manual counting from custom IO guide + switch to python from pycon