### PR TITLE
ci: add a completion job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,3 +97,16 @@ jobs:
         with:
           name: coverage-${{ matrix.package }}
           path: '**/coverage.xml'
+
+  complete:
+    name: All checks passed
+    runs-on: ubuntu-latest
+    needs:
+      - test
+      - static_code_analysis
+      - docs
+      - packages
+
+    steps:
+      - name: Complete
+        run: echo "🎉"


### PR DESCRIPTION
Required to enable status checks for branch protection, which in turn allows us to enable auto-merge