### PR TITLE
Set ordeq version constraint on ordeq-cli-runner

### DIFF
--- a/packages/ordeq-cli-runner/pyproject.toml
+++ b/packages/ordeq-cli-runner/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
     { name = "Simon Brugman" },
 ]
 requires-python = ">=3.10"
-dependencies = ["ordeq>=1.1.0"]
+dependencies = ["ordeq>=1.2.0"]
 
 [tool.ordeq]
 group = "CLI"


### PR DESCRIPTION
The latest version of `ordeq-cli-runner` is incompatible with `ordeq<=1.1.0`