### PR TITLE
perf(ordeq): optimize graph building from O(n²) to O(n)

### DIFF
--- a/packages/ordeq/src/ordeq/_graph.py
+++ b/packages/ordeq/src/ordeq/_graph.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from collections.abc import Iterable
 from graphlib import TopologicalSorter
 
@@ -23,7 +24,7 @@ def _build_graph(nodes: Iterable[Node]) -> EdgesType:
         ValueError: if an output is defined by more than one node
     """
     output_to_node: dict = {}
-    input_to_nodes: dict = {}
+    input_to_nodes: defaultdict = defaultdict(list)
     edges: dict = {node: [] for node in nodes}
     for node in nodes:
         for output_ in node.outputs:
@@ -32,7 +33,7 @@ def _build_graph(nodes: Iterable[Node]) -> EdgesType:
                 raise ValueError(msg)
             output_to_node[output_] = node
         for input_ in node.inputs:
-            input_to_nodes[input_] = [*input_to_nodes.get(input_, []), node]
+            input_to_nodes[input_].append(node)
     for node_output, node in output_to_node.items():
         if node_output in input_to_nodes:
             edges[node] += input_to_nodes[node_output]


### PR DESCRIPTION
 Optimises graph building algorithm by eliminating O(n²) complexity when multiple nodes share input dependencies.


  ```python
  input_to_nodes[input_] = [*input_to_nodes.get(input_, []), node]
   ```

  This rebuilds the entire list every time a node is added. If 100 nodes share the same input:

  Current: 1 + 2 + 3 + ... + 100 = 5,050 operations | O(n²) worst case when N nodes share same input
  Optimal: 100 operations  | O(n) with constant-time append
