### PR TITLE
perf(ordeq): optimize module deduplication with set comprehension

### DIFF
--- a/packages/ordeq/src/ordeq/_resolve.py
+++ b/packages/ordeq/src/ordeq/_resolve.py
@@ -228,9 +228,7 @@ def _resolve_runnables_to_nodes_and_modules(
                 f"Expected a module or a node, got {type(runnable)}"
             )
 
-    modules = set(
-        dict(_resolve_runnables_to_modules(*modules_and_strs)).values()
-    )
+    modules = {m for _, m in _resolve_runnables_to_modules(*modules_and_strs)}
     return nodes, modules
 
 


### PR DESCRIPTION
Module deduplication by replacing inefficient dict-to-set conversion with direct set comprehension.

 ```python
  modules = set(
      dict(_resolve_runnables_to_modules(*modules_and_strs)).values()
  )
 ```
 
 This creates unnecessary intermediate data structures as follows:
generator → dict (deduplicates by key) -> extract dict values -> convert values to set (which is redundant deduplication)