### PR TITLE
Add Memory-Mapped Array Loading Support to NumpyBinary

### DIFF
--- a/packages/ordeq-numpy/src/ordeq_numpy/binary_array.py
+++ b/packages/ordeq-numpy/src/ordeq_numpy/binary_array.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 from ordeq import IO
@@ -24,7 +25,7 @@ class NumpyBinary(IO[np.ndarray]):
 
     path: PathLike
 
-    def load(self, **load_options) -> np.ndarray:
+    def load(self, **load_options: Any) -> np.ndarray:
         """Load numpy array with optional parameters.
 
         Args:


### PR DESCRIPTION
Previously, the `NumpyBinary.load()` method would load entire arrays into RAM, which could cause out-of-memory (OOM) errors when working with large files.

| Mode | Description | Use Case |
|------|-------------|----------|
| `None` | Load into RAM (default) | Small arrays that fit in memory |
| `'r'` | Read-only memory map | Large arrays for inference/analysis |
| `'r+'` | Read-write memory map | Large arrays requiring in-place modifications |
| `'c'` | Copy-on-write | Safe modifications without affecting source file |

References:
[NumPy Memory-Mapped Files Documentation](https://numpy.org/doc/stable/reference/generated/numpy.memmap.html)
[NumPy load() with mmap_mode](https://numpy.org/doc/stable/reference/generated/numpy.load.html)
[Efficient Memory Management in NumPy](https://numpy.org/doc/stable/user/basics.creation.html#memory-mapped-files)