### PR TITLE
use cached_property for topological_ordering and sorted_edges

### DIFF
--- a/packages/ordeq/src/ordeq/_graph.py
+++ b/packages/ordeq/src/ordeq/_graph.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from functools import cached_property
 from graphlib import TopologicalSorter
 
 from ordeq._nodes import Node
@@ -86,11 +87,11 @@ class NodeGraph:
     def from_nodes(cls, nodes: Iterable[Node]) -> Self:
         return cls(_build_graph(nodes))
 
-    @property
+    @cached_property
     def topological_ordering(self) -> tuple[Node, ...]:
         return _find_topological_ordering(self.sorted_edges)
 
-    @property
+    @cached_property
     def sorted_edges(self) -> EdgesType:
         return dict(
             sorted(


### PR DESCRIPTION
adds caching to `NodeGraph` properties to eliminate redundant O(N log N) computation

before: O(N log N + M log M) per access 
- because sorts all the nodes and edges from scratch

with this PR -> O(N log N + M log M) on first access, O(1) thereafter 
- sorts everything and saves the result then afterwards just returns the saved results immediatly