### PR TITLE
`ordeq`: raise ValueError for unsupported node 'input' and 'output'

### DIFF
--- a/packages/ordeq/src/ordeq/_nodes.py
+++ b/packages/ordeq/src/ordeq/_nodes.py
@@ -427,7 +427,21 @@ def node(
     Returns:
         a node
 
+    Raises:
+        ValueError: if 'input' or 'output' is provided as keyword argument
+
     """
+
+    if "input" in attributes:
+        raise ValueError(
+            "The 'input' keyword argument is not supported. "
+            "Did you mean 'inputs'?"
+        )
+    if "output" in attributes:
+        raise ValueError(
+            "The 'output' keyword argument is not supported. "
+            "Did you mean 'outputs'?"
+        )
 
     if func is None:
         # we are called as @node(inputs=...

--- a/packages/ordeq/tests/resources/nodes/node_input.py
+++ b/packages/ordeq/tests/resources/nodes/node_input.py
@@ -1,0 +1,6 @@
+from ordeq import IO, node
+
+
+@node(input=IO(), outputs=IO())
+def my_node(a):
+    return a

--- a/packages/ordeq/tests/resources/nodes/node_output.py
+++ b/packages/ordeq/tests/resources/nodes/node_output.py
@@ -1,0 +1,6 @@
+from ordeq import IO, node
+
+
+@node(inputs=IO(), output=IO())
+def my_node(a):
+    return a

--- a/packages/ordeq/tests/snapshots/nodes/node_input.snapshot.md
+++ b/packages/ordeq/tests/snapshots/nodes/node_input.snapshot.md
@@ -1,0 +1,34 @@
+## Resource
+
+```python
+from ordeq import IO, node
+
+
+@node(input=IO(), outputs=IO())
+def my_node(a):
+    return a
+
+```
+
+## Exception
+
+```text
+ValueError: The 'input' keyword argument is not supported. Did you mean 'inputs'?
+  File "/packages/ordeq/src/ordeq/_nodes.py", line LINO, in node
+    raise ValueError(
+    ...<2 lines>...
+    )
+
+  File "/packages/ordeq/tests/resources/nodes/node_input.py", line LINO, in <module>
+    @node(input=IO(), outputs=IO())
+     ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  File "<frozen importlib._bootstrap>", line LINO, in _call_with_frames_removed
+
+  File "<frozen importlib._bootstrap_external>", line LINO, in exec_module
+
+  File "/packages/ordeq-test-utils/src/ordeq_test_utils/snapshot.py", line LINO, in run_module
+    spec.loader.exec_module(module)
+    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
+
+```

--- a/packages/ordeq/tests/snapshots/nodes/node_output.snapshot.md
+++ b/packages/ordeq/tests/snapshots/nodes/node_output.snapshot.md
@@ -1,0 +1,34 @@
+## Resource
+
+```python
+from ordeq import IO, node
+
+
+@node(inputs=IO(), output=IO())
+def my_node(a):
+    return a
+
+```
+
+## Exception
+
+```text
+ValueError: The 'output' keyword argument is not supported. Did you mean 'outputs'?
+  File "/packages/ordeq/src/ordeq/_nodes.py", line LINO, in node
+    raise ValueError(
+    ...<2 lines>...
+    )
+
+  File "/packages/ordeq/tests/resources/nodes/node_output.py", line LINO, in <module>
+    @node(inputs=IO(), output=IO())
+     ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+  File "<frozen importlib._bootstrap>", line LINO, in _call_with_frames_removed
+
+  File "<frozen importlib._bootstrap_external>", line LINO, in exec_module
+
+  File "/packages/ordeq-test-utils/src/ordeq_test_utils/snapshot.py", line LINO, in run_module
+    spec.loader.exec_module(module)
+    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
+
+```

--- a/packages/ordeq/tests/snapshots/typing.snapshot.md
+++ b/packages/ordeq/tests/snapshots/typing.snapshot.md
@@ -52,4 +52,4 @@ packages/ordeq/tests/resources/views/standalone_view_df_filter.py:18: error: No 
 packages/ordeq/tests/resources/views/standalone_view_df_filter.py:18: note: Possible overload variants:
 packages/ordeq/tests/resources/views/standalone_view_df_filter.py:18: note:     def where(self, cond: Series[Any] | DataFrame | ndarray[tuple[Any, ...], dtype[Any]] | Callable[[DataFrame], DataFrame] | Callable[[Any], bool], other: Any = ..., *, inplace: Literal[True], axis: Literal['index', 0] | Literal['columns', 1] | None = ..., level: Hashable | None = ...) -> None
 packages/ordeq/tests/resources/views/standalone_view_df_filter.py:18: note:     def where(self, cond: Series[Any] | DataFrame | ndarray[tuple[Any, ...], dtype[Any]] | Callable[[DataFrame], DataFrame] | Callable[[Any], bool], other: Any = ..., *, inplace: Literal[False] = ..., axis: Literal['index', 0, 'columns', 1] | None = ..., level: Hashable | None = ...) -> DataFrame
-Found 35 errors in 25 files (checked 134 source files)
+Found 35 errors in 25 files (checked 136 source files)


### PR DESCRIPTION
raise ValueError for unsupported node 'input' and 'output' keyword arguments