### PR TITLE
`ordeq-dev-tools`: use resource syntax

### DIFF
--- a/packages/ordeq-dev-tools/src/ordeq_dev_tools/pipelines/docs_update_just.py
+++ b/packages/ordeq-dev-tools/src/ordeq_dev_tools/pipelines/docs_update_just.py
@@ -8,7 +8,7 @@ from ordeq_dev_tools.utils import run_command
 
 contribution_guide = Text(path=ROOT_PATH / "docs" / "CONTRIBUTING.md")
 docs_file = contribution_guide @ "existing"
-updated_docs_file = docs_file @ "new"
+updated_docs_file = contribution_guide @ "new"
 
 
 @node


### PR DESCRIPTION
Syntax for resources is available since 1.3.1.

Pending for the runner/graph to be updated.